### PR TITLE
fix: add logs to mcp server folder as default to store its logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-04-02
+
+### Fixed
+- Fixed logs directory creation issue where logs were being created in the root directory instead of the application directory
+- Updated both index.ts and mcp-server.ts to use ESM equivalent of __dirname instead of process.cwd()
+
 ## [1.0.0] - 2025-03-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-server-simulator-ios-idb",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Model Context Protocol server for iOS simulator automation via IDB",
   "main": "dist/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ console.debug = () => {};
 
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import mcpServer from './mcp/mcp-server.js';
 
 /**
@@ -79,7 +80,12 @@ export function createMCPServer() {
 
 // Create logs directory with error handling
 try {
-  const logsDir = path.join(process.cwd(), 'logs');
+  // Get the directory name using ESM approach
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  // Go up one level from the src directory to the project root
+  const logsDir = path.join(__dirname, '..', 'logs');
+  
   if (!fs.existsSync(logsDir)) {
     fs.mkdirSync(logsDir, { recursive: true });
   }

--- a/src/mcp/mcp-server.ts
+++ b/src/mcp/mcp-server.ts
@@ -10,11 +10,16 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 import { createMCPServer } from '../index.js';
 
 // Log configuration
-const logsDir = path.join(process.cwd(), 'logs');
+// Get the directory name using ESM approach
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Go up two levels from the src/mcp directory to the project root
+const logsDir = path.join(__dirname, '..', '..', 'logs');
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true });
 }
@@ -46,7 +51,7 @@ class MCPSimulatorServer {
     this.server = new Server(
       {
         name: 'iOS Simulator MCP Server',
-        version: '1.0.0',
+        version: '1.0.1',
       },
       {
         capabilities: {


### PR DESCRIPTION
This pull request includes updates to fix the logs directory creation issue raised in #5  and version bumps. 