### PR TITLE
Update Contributor License Agreement instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ this project.
 
 ## Prerequisites
 
-- Before starting to contribute to the code, you must first sign the [Contributor License Agreement (CLA)](https://github.com/InditexTech/foss/blob/main/documents/ITX_OSS_CLA.pdf).
+- Before starting to contribute to the code, you must first sign the Contributor License Agreement (CLA). Detailed
+  instructions on how to proceed can be found in the
+  [FOSS contributing guidelines](https://github.com/InditexTech/foss/blob/main/CONTRIBUTING.md).
 
 ## How to Contribute
 


### PR DESCRIPTION
Clarified instructions for signing the Contributor License Agreement and added reference to FOSS contributing guidelines.