### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,8 @@ This project would not be possible without [facebook/idb](https://github.com/fac
 ## 📄 License
 
 This tool is available as open source under the terms of the Apache-2.0.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/inditextech-mcp-server-simulator-ios-idb).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/inditextech-mcp-server-simulator-ios-idb).